### PR TITLE
Add basic pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ By using this software, you agree to use it solely for learning purposes.
   - [Using Docker](#using-docker)
 - [Usage](#usage)
   - [Running the Hedge Fund](#running-the-hedge-fund)
-  - [Running the Backtester](#running-the-backtester)
+- [Running the Backtester](#running-the-backtester)
+- [Running Tests](#running-tests)
 - [Project Structure](#project-structure)
 - [Contributing](#contributing)
 - [Feature Requests](#feature-requests)
@@ -231,8 +232,16 @@ poetry run python src/backtester.py --ticker AAPL,MSFT,NVDA --ollama
 run.bat --ticker AAPL,MSFT,NVDA --ollama backtest
 ```
 
+### Running Tests
 
-## Project Structure 
+Run the unit tests with [pytest](https://pytest.org/):
+
+```bash
+poetry run pytest
+```
+
+
+## Project Structure
 ```
 ai-hedge-fund/
 ├── src/

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,0 +1,48 @@
+from src.backtester import Backtester
+
+
+def create_backtester(cash=1000.0, margin=0.0):
+    return Backtester(
+        agent=lambda **kwargs: None,
+        tickers=["AAPL"],
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        initial_capital=cash,
+        initial_margin_requirement=margin,
+    )
+
+
+def test_execute_trade_buy_and_sell():
+    bt = create_backtester()
+
+    qty = bt.execute_trade("AAPL", "buy", 10, 10.0)
+    assert qty == 10
+    assert bt.portfolio["cash"] == 900.0
+    pos = bt.portfolio["positions"]["AAPL"]
+    assert pos["long"] == 10
+    assert pos["long_cost_basis"] == 10.0
+
+    qty = bt.execute_trade("AAPL", "sell", 5, 15.0)
+    assert qty == 5
+    assert bt.portfolio["cash"] == 975.0
+    assert pos["long"] == 5
+    assert bt.portfolio["realized_gains"]["AAPL"]["long"] == 25.0
+
+
+def test_execute_trade_short_and_cover():
+    bt = create_backtester(margin=0.5)
+
+    qty = bt.execute_trade("AAPL", "short", 5, 10.0)
+    assert qty == 5
+    pos = bt.portfolio["positions"]["AAPL"]
+    assert pos["short"] == 5
+    assert pos["short_cost_basis"] == 10.0
+    assert bt.portfolio["cash"] == 1025.0
+    assert bt.portfolio["margin_used"] == 25.0
+
+    qty = bt.execute_trade("AAPL", "cover", 3, 8.0)
+    assert qty == 3
+    assert pos["short"] == 2
+    assert bt.portfolio["cash"] == 1016.0
+    assert bt.portfolio["margin_used"] == 10.0
+    assert bt.portfolio["realized_gains"]["AAPL"]["short"] == 6.0

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,58 @@
+from pydantic import BaseModel
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.utils.llm import call_llm
+
+
+class DummyLLM:
+    def __init__(self, result):
+        self.result = result
+        self.with_structured_called = False
+        self.model = None
+
+    def with_structured_output(self, model_cls, method="json_mode"):
+        self.with_structured_called = True
+        self.model = model_cls
+        return self
+
+    def invoke(self, prompt):
+        return self.result
+
+
+class JSONModel(BaseModel):
+    foo: str
+
+
+def test_call_llm_json_mode():
+    expected = JSONModel(foo="bar")
+    dummy_llm = DummyLLM(expected)
+
+    class Info:
+        def has_json_mode(self):
+            return True
+
+    with patch("src.utils.llm.get_model_info", return_value=Info()), \
+         patch("src.utils.llm.get_model", return_value=dummy_llm):
+        result = call_llm("prompt", "model", "provider", JSONModel)
+
+    assert result == expected
+    assert dummy_llm.with_structured_called
+    assert dummy_llm.model is JSONModel
+
+
+def test_call_llm_non_json_mode():
+    response = SimpleNamespace(content="```json\n{\"foo\": \"bar\"}\n```")
+    dummy_llm = DummyLLM(response)
+
+    class Info:
+        def has_json_mode(self):
+            return False
+
+    with patch("src.utils.llm.get_model_info", return_value=Info()), \
+         patch("src.utils.llm.get_model", return_value=dummy_llm):
+        result = call_llm("prompt", "model", "provider", JSONModel)
+
+    assert isinstance(result, JSONModel)
+    assert result.foo == "bar"
+    assert not dummy_llm.with_structured_called


### PR DESCRIPTION
## Summary
- create `tests/` directory and add unit tests
- cover `call_llm` util and `Backtester.execute_trade`
- document how to run the tests with pytest

## Testing
- `poetry run pytest -q` *(fails: Command not found: pytest)*