### PR TITLE
Fix typing of generic dict

### DIFF
--- a/src/agents/ben_graham.py
+++ b/src/agents/ben_graham.py
@@ -1,13 +1,16 @@
+import json
+import math
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel
+from typing_extensions import Literal
+
 from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel
-import json
-from typing_extensions import Literal
-from src.utils.progress import progress
 from src.utils.llm import call_llm
-import math
+from src.utils.progress import progress
 
 
 class BenGrahamSignal(BaseModel):
@@ -279,7 +282,7 @@ def analyze_valuation_graham(financial_line_items: list, market_cap: float) -> d
 
 def generate_graham_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> BenGrahamSignal:

--- a/src/agents/bill_ackman.py
+++ b/src/agents/bill_ackman.py
@@ -1,13 +1,16 @@
+import json
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
+from pydantic import BaseModel
+from typing_extensions import Literal
+
 from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel
-import json
-from typing_extensions import Literal
-from src.utils.progress import progress
 from src.utils.llm import call_llm
+from src.utils.progress import progress
 
 
 class BillAckmanSignal(BaseModel):
@@ -25,14 +28,14 @@ def bill_ackman_agent(state: AgentState):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    
+
     analysis_data = {}
     ackman_analysis = {}
-    
+
     for ticker in tickers:
         progress.update_status("bill_ackman_agent", ticker, "Fetching financial metrics")
         metrics = get_financial_metrics(ticker, end_date, period="annual", limit=5)
-        
+
         progress.update_status("bill_ackman_agent", ticker, "Gathering financial line items")
         # Request multiple periods of data (annual or TTM) for a more robust long-term view.
         financial_line_items = search_line_items(
@@ -51,33 +54,28 @@ def bill_ackman_agent(state: AgentState):
             ],
             end_date,
             period="annual",
-            limit=5
+            limit=5,
         )
-        
+
         progress.update_status("bill_ackman_agent", ticker, "Getting market cap")
         market_cap = get_market_cap(ticker, end_date)
-        
+
         progress.update_status("bill_ackman_agent", ticker, "Analyzing business quality")
         quality_analysis = analyze_business_quality(metrics, financial_line_items)
-        
+
         progress.update_status("bill_ackman_agent", ticker, "Analyzing balance sheet and capital structure")
         balance_sheet_analysis = analyze_financial_discipline(metrics, financial_line_items)
-        
+
         progress.update_status("bill_ackman_agent", ticker, "Analyzing activism potential")
         activism_analysis = analyze_activism_potential(financial_line_items)
-        
+
         progress.update_status("bill_ackman_agent", ticker, "Calculating intrinsic value & margin of safety")
         valuation_analysis = analyze_valuation(financial_line_items, market_cap)
-        
+
         # Combine partial scores or signals
-        total_score = (
-            quality_analysis["score"]
-            + balance_sheet_analysis["score"]
-            + activism_analysis["score"]
-            + valuation_analysis["score"]
-        )
+        total_score = quality_analysis["score"] + balance_sheet_analysis["score"] + activism_analysis["score"] + valuation_analysis["score"]
         max_possible_score = 20  # Adjust weighting as desired (5 from each sub-analysis, for instance)
-        
+
         # Generate a simple buy/hold/sell (bullish/neutral/bearish) signal
         if total_score >= 0.7 * max_possible_score:
             signal = "bullish"
@@ -85,52 +83,34 @@ def bill_ackman_agent(state: AgentState):
             signal = "bearish"
         else:
             signal = "neutral"
-        
-        analysis_data[ticker] = {
-            "signal": signal,
-            "score": total_score,
-            "max_score": max_possible_score,
-            "quality_analysis": quality_analysis,
-            "balance_sheet_analysis": balance_sheet_analysis,
-            "activism_analysis": activism_analysis,
-            "valuation_analysis": valuation_analysis
-        }
-        
+
+        analysis_data[ticker] = {"signal": signal, "score": total_score, "max_score": max_possible_score, "quality_analysis": quality_analysis, "balance_sheet_analysis": balance_sheet_analysis, "activism_analysis": activism_analysis, "valuation_analysis": valuation_analysis}
+
         progress.update_status("bill_ackman_agent", ticker, "Generating Bill Ackman analysis")
         ackman_output = generate_ackman_output(
-            ticker=ticker, 
+            ticker=ticker,
             analysis_data=analysis_data,
             model_name=state["metadata"]["model_name"],
             model_provider=state["metadata"]["model_provider"],
         )
-        
-        ackman_analysis[ticker] = {
-            "signal": ackman_output.signal,
-            "confidence": ackman_output.confidence,
-            "reasoning": ackman_output.reasoning
-        }
-        
+
+        ackman_analysis[ticker] = {"signal": ackman_output.signal, "confidence": ackman_output.confidence, "reasoning": ackman_output.reasoning}
+
         progress.update_status("bill_ackman_agent", ticker, "Done")
-    
+
     # Wrap results in a single message for the chain
-    message = HumanMessage(
-        content=json.dumps(ackman_analysis),
-        name="bill_ackman_agent"
-    )
-    
+    message = HumanMessage(content=json.dumps(ackman_analysis), name="bill_ackman_agent")
+
     # Show reasoning if requested
     if state["metadata"]["show_reasoning"]:
         show_agent_reasoning(ackman_analysis, "Bill Ackman Agent")
-    
+
     # Add signals to the overall state
     state["data"]["analyst_signals"]["bill_ackman_agent"] = ackman_analysis
 
     progress.update_status("bill_ackman_agent", None, "Done")
 
-    return {
-        "messages": [message],
-        "data": state["data"]
-    }
+    return {"messages": [message], "data": state["data"]}
 
 
 def analyze_business_quality(metrics: list, financial_line_items: list) -> dict:
@@ -141,13 +121,10 @@ def analyze_business_quality(metrics: list, financial_line_items: list) -> dict:
     """
     score = 0
     details = []
-    
+
     if not metrics or not financial_line_items:
-        return {
-            "score": 0,
-            "details": "Insufficient data to analyze business quality"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to analyze business quality"}
+
     # 1. Multi-period revenue growth analysis
     revenues = [item.revenue for item in financial_line_items if item.revenue is not None]
     if len(revenues) >= 2:
@@ -164,11 +141,11 @@ def analyze_business_quality(metrics: list, financial_line_items: list) -> dict:
             details.append("Revenue did not grow significantly or data insufficient.")
     else:
         details.append("Not enough revenue data for multi-period trend.")
-    
+
     # 2. Operating margin and free cash flow consistency
     fcf_vals = [item.free_cash_flow for item in financial_line_items if item.free_cash_flow is not None]
     op_margin_vals = [item.operating_margin for item in financial_line_items if item.operating_margin is not None]
-    
+
     if op_margin_vals:
         above_15 = sum(1 for m in op_margin_vals if m > 0.15)
         if above_15 >= (len(op_margin_vals) // 2 + 1):
@@ -178,7 +155,7 @@ def analyze_business_quality(metrics: list, financial_line_items: list) -> dict:
             details.append("Operating margin not consistently above 15%.")
     else:
         details.append("No operating margin data across periods.")
-    
+
     if fcf_vals:
         positive_fcf_count = sum(1 for f in fcf_vals if f > 0)
         if positive_fcf_count >= (len(fcf_vals) // 2 + 1):
@@ -188,7 +165,7 @@ def analyze_business_quality(metrics: list, financial_line_items: list) -> dict:
             details.append("Free cash flow not consistently positive.")
     else:
         details.append("No free cash flow data across periods.")
-    
+
     # 3. Return on Equity (ROE) check from the latest metrics
     latest_metrics = metrics[0]
     if latest_metrics.return_on_equity and latest_metrics.return_on_equity > 0.15:
@@ -198,17 +175,14 @@ def analyze_business_quality(metrics: list, financial_line_items: list) -> dict:
         details.append(f"ROE of {latest_metrics.return_on_equity:.1%} is moderate.")
     else:
         details.append("ROE data not available.")
-    
+
     # 4. (Optional) Brand Intangible (if intangible_assets are fetched)
     # intangible_vals = [item.intangible_assets for item in financial_line_items if item.intangible_assets]
     # if intangible_vals and sum(intangible_vals) > 0:
     #     details.append("Significant intangible assets may indicate brand value or proprietary tech.")
     #     score += 1
-    
-    return {
-        "score": score,
-        "details": "; ".join(details)
-    }
+
+    return {"score": score, "details": "; ".join(details)}
 
 
 def analyze_financial_discipline(metrics: list, financial_line_items: list) -> dict:
@@ -219,13 +193,10 @@ def analyze_financial_discipline(metrics: list, financial_line_items: list) -> d
     """
     score = 0
     details = []
-    
+
     if not metrics or not financial_line_items:
-        return {
-            "score": 0,
-            "details": "Insufficient data to analyze financial discipline"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to analyze financial discipline"}
+
     # 1. Multi-period debt ratio or debt_to_equity
     debt_to_equity_vals = [item.debt_to_equity for item in financial_line_items if item.debt_to_equity is not None]
     if debt_to_equity_vals:
@@ -241,7 +212,7 @@ def analyze_financial_discipline(metrics: list, financial_line_items: list) -> d
         for item in financial_line_items:
             if item.total_liabilities and item.total_assets and item.total_assets > 0:
                 liab_to_assets.append(item.total_liabilities / item.total_assets)
-        
+
         if liab_to_assets:
             below_50pct_count = sum(1 for ratio in liab_to_assets if ratio < 0.5)
             if below_50pct_count >= (len(liab_to_assets) // 2 + 1):
@@ -251,13 +222,9 @@ def analyze_financial_discipline(metrics: list, financial_line_items: list) -> d
                 details.append("Liabilities-to-assets >= 50% in many periods.")
         else:
             details.append("No consistent leverage ratio data available.")
-    
+
     # 2. Capital allocation approach (dividends + share counts)
-    dividends_list = [
-        item.dividends_and_other_cash_distributions
-        for item in financial_line_items
-        if item.dividends_and_other_cash_distributions is not None
-    ]
+    dividends_list = [item.dividends_and_other_cash_distributions for item in financial_line_items if item.dividends_and_other_cash_distributions is not None]
     if dividends_list:
         paying_dividends_count = sum(1 for d in dividends_list if d < 0)
         if paying_dividends_count >= (len(dividends_list) // 2 + 1):
@@ -267,7 +234,7 @@ def analyze_financial_discipline(metrics: list, financial_line_items: list) -> d
             details.append("Dividends not consistently paid or no data on distributions.")
     else:
         details.append("No dividend data found across periods.")
-    
+
     # Check for decreasing share count (simple approach)
     shares = [item.outstanding_shares for item in financial_line_items if item.outstanding_shares is not None]
     if len(shares) >= 2:
@@ -279,55 +246,43 @@ def analyze_financial_discipline(metrics: list, financial_line_items: list) -> d
             details.append("Outstanding shares have not decreased over the available periods.")
     else:
         details.append("No multi-period share count data to assess buybacks.")
-    
-    return {
-        "score": score,
-        "details": "; ".join(details)
-    }
+
+    return {"score": score, "details": "; ".join(details)}
 
 
 def analyze_activism_potential(financial_line_items: list) -> dict:
     """
     Bill Ackman often engages in activism if a company has a decent brand or moat
     but is underperforming operationally.
-    
+
     We'll do a simplified approach:
     - Look for positive revenue trends but subpar margins
     - That may indicate 'activism upside' if operational improvements could unlock value.
     """
     if not financial_line_items:
-        return {
-            "score": 0,
-            "details": "Insufficient data for activism potential"
-        }
-    
+        return {"score": 0, "details": "Insufficient data for activism potential"}
+
     # Check revenue growth vs. operating margin
     revenues = [item.revenue for item in financial_line_items if item.revenue is not None]
     op_margins = [item.operating_margin for item in financial_line_items if item.operating_margin is not None]
-    
+
     if len(revenues) < 2 or not op_margins:
-        return {
-            "score": 0,
-            "details": "Not enough data to assess activism potential (need multi-year revenue + margins)."
-        }
-    
+        return {"score": 0, "details": "Not enough data to assess activism potential (need multi-year revenue + margins)."}
+
     initial, final = revenues[-1], revenues[0]
     revenue_growth = (final - initial) / abs(initial) if initial else 0
     avg_margin = sum(op_margins) / len(op_margins)
-    
+
     score = 0
     details = []
-    
+
     # Suppose if there's decent revenue growth but margins are below 10%, Ackman might see activism potential.
     if revenue_growth > 0.15 and avg_margin < 0.10:
         score += 2
-        details.append(
-            f"Revenue growth is healthy (~{revenue_growth*100:.1f}%), but margins are low (avg {avg_margin*100:.1f}%). "
-            "Activism could unlock margin improvements."
-        )
+        details.append(f"Revenue growth is healthy (~{revenue_growth*100:.1f}%), but margins are low (avg {avg_margin*100:.1f}%). " "Activism could unlock margin improvements.")
     else:
         details.append("No clear sign of activism opportunity (either margins are already decent or growth is weak).")
-    
+
     return {"score": score, "details": "; ".join(details)}
 
 
@@ -337,79 +292,62 @@ def analyze_valuation(financial_line_items: list, market_cap: float) -> dict:
     Uses a simplified DCF with FCF as a proxy, plus margin of safety analysis.
     """
     if not financial_line_items or market_cap is None:
-        return {
-            "score": 0,
-            "details": "Insufficient data to perform valuation"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to perform valuation"}
+
     # Since financial_line_items are in descending order (newest first),
     # the most recent period is the first element
     latest = financial_line_items[0]
     fcf = latest.free_cash_flow if latest.free_cash_flow else 0
-    
+
     if fcf <= 0:
-        return {
-            "score": 0,
-            "details": f"No positive FCF for valuation; FCF = {fcf}",
-            "intrinsic_value": None
-        }
-    
+        return {"score": 0, "details": f"No positive FCF for valuation; FCF = {fcf}", "intrinsic_value": None}
+
     # Basic DCF assumptions
     growth_rate = 0.06
     discount_rate = 0.10
     terminal_multiple = 15
     projection_years = 5
-    
+
     present_value = 0
     for year in range(1, projection_years + 1):
         future_fcf = fcf * (1 + growth_rate) ** year
         pv = future_fcf / ((1 + discount_rate) ** year)
         present_value += pv
-    
+
     # Terminal Value
-    terminal_value = (
-        fcf * (1 + growth_rate) ** projection_years * terminal_multiple
-    ) / ((1 + discount_rate) ** projection_years)
-    
+    terminal_value = (fcf * (1 + growth_rate) ** projection_years * terminal_multiple) / ((1 + discount_rate) ** projection_years)
+
     intrinsic_value = present_value + terminal_value
     margin_of_safety = (intrinsic_value - market_cap) / market_cap
-    
+
     score = 0
     # Simple scoring
     if margin_of_safety > 0.3:
         score += 3
     elif margin_of_safety > 0.1:
         score += 1
-    
-    details = [
-        f"Calculated intrinsic value: ~{intrinsic_value:,.2f}",
-        f"Market cap: ~{market_cap:,.2f}",
-        f"Margin of safety: {margin_of_safety:.2%}"
-    ]
-    
-    return {
-        "score": score,
-        "details": "; ".join(details),
-        "intrinsic_value": intrinsic_value,
-        "margin_of_safety": margin_of_safety
-    }
+
+    details = [f"Calculated intrinsic value: ~{intrinsic_value:,.2f}", f"Market cap: ~{market_cap:,.2f}", f"Margin of safety: {margin_of_safety:.2%}"]
+
+    return {"score": score, "details": "; ".join(details), "intrinsic_value": intrinsic_value, "margin_of_safety": margin_of_safety}
 
 
 def generate_ackman_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> BillAckmanSignal:
     """
     Generates investment decisions in the style of Bill Ackman.
-    Includes more explicit references to brand strength, activism potential, 
+    Includes more explicit references to brand strength, activism potential,
     catalysts, and management changes in the system prompt.
     """
-    template = ChatPromptTemplate.from_messages([
-        (
-            "system",
-            """You are a Bill Ackman AI agent, making investment decisions using his principles:
+    template = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are a Bill Ackman AI agent, making investment decisions using his principles:
 
             1. Seek high-quality businesses with durable competitive advantages (moats), often in well-known consumer or service brands.
             2. Prioritize consistent free cash flow and growth potential over the long term.
@@ -427,11 +365,11 @@ def generate_ackman_output(
             - Use a confident, analytic, and sometimes confrontational tone when discussing weaknesses or opportunities.
 
             Return your final recommendation (signal: bullish, neutral, or bearish) with a 0-100 confidence and a thorough reasoning section.
-            """
-        ),
-        (
-            "human",
-            """Based on the following analysis, create an Ackman-style investment signal.
+            """,
+            ),
+            (
+                "human",
+                """Based on the following analysis, create an Ackman-style investment signal.
 
             Analysis Data for {ticker}:
             {analysis_data}
@@ -442,27 +380,21 @@ def generate_ackman_output(
               "confidence": float (0-100),
               "reasoning": "string"
             }}
-            """
-        )
-    ])
+            """,
+            ),
+        ]
+    )
 
-    prompt = template.invoke({
-        "analysis_data": json.dumps(analysis_data, indent=2),
-        "ticker": ticker
-    })
+    prompt = template.invoke({"analysis_data": json.dumps(analysis_data, indent=2), "ticker": ticker})
 
     def create_default_bill_ackman_signal():
-        return BillAckmanSignal(
-            signal="neutral",
-            confidence=0.0,
-            reasoning="Error in analysis, defaulting to neutral"
-        )
+        return BillAckmanSignal(signal="neutral", confidence=0.0, reasoning="Error in analysis, defaulting to neutral")
 
     return call_llm(
-        prompt=prompt, 
-        model_name=model_name, 
-        model_provider=model_provider, 
-        pydantic_model=BillAckmanSignal, 
-        agent_name="bill_ackman_agent", 
+        prompt=prompt,
+        model_name=model_name,
+        model_provider=model_provider,
+        pydantic_model=BillAckmanSignal,
+        agent_name="bill_ackman_agent",
         default_factory=create_default_bill_ackman_signal,
     )

--- a/src/agents/cathie_wood.py
+++ b/src/agents/cathie_wood.py
@@ -1,12 +1,15 @@
+import json
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel
+from typing_extensions import Literal
+
 from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel
-import json
-from typing_extensions import Literal
-from src.utils.progress import progress
 from src.utils.llm import call_llm
+from src.utils.progress import progress
 
 
 class CathieWoodSignal(BaseModel):
@@ -360,7 +363,7 @@ def analyze_cathie_wood_valuation(financial_line_items: list, market_cap: float)
 
 def generate_cathie_wood_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> CathieWoodSignal:

--- a/src/agents/charlie_munger.py
+++ b/src/agents/charlie_munger.py
@@ -1,12 +1,22 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from src.tools.api import get_financial_metrics, get_market_cap, search_line_items, get_insider_trades, get_company_news
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel
 import json
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel
 from typing_extensions import Literal
-from src.utils.progress import progress
+
+from src.graph.state import AgentState, show_agent_reasoning
+from src.tools.api import (
+    get_company_news,
+    get_financial_metrics,
+    get_insider_trades,
+    get_market_cap,
+    search_line_items,
+)
 from src.utils.llm import call_llm
+from src.utils.progress import progress
+
 
 class CharlieMungerSignal(BaseModel):
     signal: Literal["bullish", "bearish", "neutral"]
@@ -22,14 +32,14 @@ def charlie_munger_agent(state: AgentState):
     data = state["data"]
     end_date = data["end_date"]
     tickers = data["tickers"]
-    
+
     analysis_data = {}
     munger_analysis = {}
-    
+
     for ticker in tickers:
         progress.update_status("charlie_munger_agent", ticker, "Fetching financial metrics")
         metrics = get_financial_metrics(ticker, end_date, period="annual", limit=10)  # Munger looks at longer periods
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Gathering financial line items")
         financial_line_items = search_line_items(
             ticker,
@@ -51,12 +61,12 @@ def charlie_munger_agent(state: AgentState):
             ],
             end_date,
             period="annual",
-            limit=10  # Munger examines long-term trends
+            limit=10,  # Munger examines long-term trends
         )
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Getting market cap")
         market_cap = get_market_cap(ticker, end_date)
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Fetching insider trades")
         # Munger values management with skin in the game
         insider_trades = get_insider_trades(
@@ -64,9 +74,9 @@ def charlie_munger_agent(state: AgentState):
             end_date,
             # Look back 2 years for insider trading patterns
             start_date=None,
-            limit=100
+            limit=100,
         )
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Fetching company news")
         # Munger avoids businesses with frequent negative press
         company_news = get_company_news(
@@ -74,32 +84,27 @@ def charlie_munger_agent(state: AgentState):
             end_date,
             # Look back 1 year for news
             start_date=None,
-            limit=100
+            limit=100,
         )
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Analyzing moat strength")
         moat_analysis = analyze_moat_strength(metrics, financial_line_items)
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Analyzing management quality")
         management_analysis = analyze_management_quality(financial_line_items, insider_trades)
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Analyzing business predictability")
         predictability_analysis = analyze_predictability(financial_line_items)
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Calculating Munger-style valuation")
         valuation_analysis = calculate_munger_valuation(financial_line_items, market_cap)
-        
+
         # Combine partial scores with Munger's weighting preferences
         # Munger weights quality and predictability higher than current valuation
-        total_score = (
-            moat_analysis["score"] * 0.35 +
-            management_analysis["score"] * 0.25 +
-            predictability_analysis["score"] * 0.25 +
-            valuation_analysis["score"] * 0.15
-        )
-        
+        total_score = moat_analysis["score"] * 0.35 + management_analysis["score"] * 0.25 + predictability_analysis["score"] * 0.25 + valuation_analysis["score"] * 0.15
+
         max_possible_score = 10  # Scale to 0-10
-        
+
         # Generate a simple buy/hold/sell signal
         if total_score >= 7.5:  # Munger has very high standards
             signal = "bullish"
@@ -107,7 +112,7 @@ def charlie_munger_agent(state: AgentState):
             signal = "bearish"
         else:
             signal = "neutral"
-        
+
         analysis_data[ticker] = {
             "signal": signal,
             "score": total_score,
@@ -117,44 +122,34 @@ def charlie_munger_agent(state: AgentState):
             "predictability_analysis": predictability_analysis,
             "valuation_analysis": valuation_analysis,
             # Include some qualitative assessment from news
-            "news_sentiment": analyze_news_sentiment(company_news) if company_news else "No news data available"
+            "news_sentiment": analyze_news_sentiment(company_news) if company_news else "No news data available",
         }
-        
+
         progress.update_status("charlie_munger_agent", ticker, "Generating Charlie Munger analysis")
         munger_output = generate_munger_output(
-            ticker=ticker, 
+            ticker=ticker,
             analysis_data=analysis_data,
             model_name=state["metadata"]["model_name"],
             model_provider=state["metadata"]["model_provider"],
         )
-        
-        munger_analysis[ticker] = {
-            "signal": munger_output.signal,
-            "confidence": munger_output.confidence,
-            "reasoning": munger_output.reasoning
-        }
-        
+
+        munger_analysis[ticker] = {"signal": munger_output.signal, "confidence": munger_output.confidence, "reasoning": munger_output.reasoning}
+
         progress.update_status("charlie_munger_agent", ticker, "Done")
-    
+
     # Wrap results in a single message for the chain
-    message = HumanMessage(
-        content=json.dumps(munger_analysis),
-        name="charlie_munger_agent"
-    )
-    
+    message = HumanMessage(content=json.dumps(munger_analysis), name="charlie_munger_agent")
+
     # Show reasoning if requested
     if state["metadata"]["show_reasoning"]:
         show_agent_reasoning(munger_analysis, "Charlie Munger Agent")
 
     progress.update_status("charlie_munger_agent", None, "Done")
-    
+
     # Add signals to the overall state
     state["data"]["analyst_signals"]["charlie_munger_agent"] = munger_analysis
 
-    return {
-        "messages": [message],
-        "data": state["data"]
-    }
+    return {"messages": [message], "data": state["data"]}
 
 
 def analyze_moat_strength(metrics: list, financial_line_items: list) -> dict:
@@ -167,17 +162,13 @@ def analyze_moat_strength(metrics: list, financial_line_items: list) -> dict:
     """
     score = 0
     details = []
-    
+
     if not metrics or not financial_line_items:
-        return {
-            "score": 0,
-            "details": "Insufficient data to analyze moat strength"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to analyze moat strength"}
+
     # 1. Return on Invested Capital (ROIC) analysis - Munger's favorite metric
-    roic_values = [item.return_on_invested_capital for item in financial_line_items 
-                   if hasattr(item, 'return_on_invested_capital') and item.return_on_invested_capital is not None]
-    
+    roic_values = [item.return_on_invested_capital for item in financial_line_items if hasattr(item, "return_on_invested_capital") and item.return_on_invested_capital is not None]
+
     if roic_values:
         # Check if ROIC consistently above 15% (Munger's threshold)
         high_roic_count = sum(1 for r in roic_values if r > 0.15)
@@ -194,14 +185,13 @@ def analyze_moat_strength(metrics: list, financial_line_items: list) -> dict:
             details.append("Poor ROIC: Never exceeds 15% threshold")
     else:
         details.append("No ROIC data available")
-    
+
     # 2. Pricing power - check gross margin stability and trends
-    gross_margins = [item.gross_margin for item in financial_line_items 
-                    if hasattr(item, 'gross_margin') and item.gross_margin is not None]
-    
+    gross_margins = [item.gross_margin for item in financial_line_items if hasattr(item, "gross_margin") and item.gross_margin is not None]
+
     if gross_margins and len(gross_margins) >= 3:
         # Munger likes stable or improving gross margins
-        margin_trend = sum(1 for i in range(1, len(gross_margins)) if gross_margins[i] >= gross_margins[i-1])
+        margin_trend = sum(1 for i in range(1, len(gross_margins)) if gross_margins[i] >= gross_margins[i - 1])
         if margin_trend >= len(gross_margins) * 0.7:  # Improving in 70% of periods
             score += 2
             details.append("Strong pricing power: Gross margins consistently improving")
@@ -212,17 +202,16 @@ def analyze_moat_strength(metrics: list, financial_line_items: list) -> dict:
             details.append("Limited pricing power: Low or declining gross margins")
     else:
         details.append("Insufficient gross margin data")
-    
+
     # 3. Capital intensity - Munger prefers low capex businesses
     if len(financial_line_items) >= 3:
         capex_to_revenue = []
         for item in financial_line_items:
-            if (hasattr(item, 'capital_expenditure') and item.capital_expenditure is not None and 
-                hasattr(item, 'revenue') and item.revenue is not None and item.revenue > 0):
+            if hasattr(item, "capital_expenditure") and item.capital_expenditure is not None and hasattr(item, "revenue") and item.revenue is not None and item.revenue > 0:
                 # Note: capital_expenditure is typically negative in financial statements
                 capex_ratio = abs(item.capital_expenditure) / item.revenue
                 capex_to_revenue.append(capex_ratio)
-        
+
         if capex_to_revenue:
             avg_capex_ratio = sum(capex_to_revenue) / len(capex_to_revenue)
             if avg_capex_ratio < 0.05:  # Less than 5% of revenue
@@ -237,30 +226,25 @@ def analyze_moat_strength(metrics: list, financial_line_items: list) -> dict:
             details.append("No capital expenditure data available")
     else:
         details.append("Insufficient data for capital intensity analysis")
-    
+
     # 4. Intangible assets - Munger values R&D and intellectual property
-    r_and_d = [item.research_and_development for item in financial_line_items
-              if hasattr(item, 'research_and_development') and item.research_and_development is not None]
-    
-    goodwill_and_intangible_assets = [item.goodwill_and_intangible_assets for item in financial_line_items
-               if hasattr(item, 'goodwill_and_intangible_assets') and item.goodwill_and_intangible_assets is not None]
+    r_and_d = [item.research_and_development for item in financial_line_items if hasattr(item, "research_and_development") and item.research_and_development is not None]
+
+    goodwill_and_intangible_assets = [item.goodwill_and_intangible_assets for item in financial_line_items if hasattr(item, "goodwill_and_intangible_assets") and item.goodwill_and_intangible_assets is not None]
 
     if r_and_d and len(r_and_d) > 0:
         if sum(r_and_d) > 0:  # If company is investing in R&D
             score += 1
             details.append("Invests in R&D, building intellectual property")
-    
-    if (goodwill_and_intangible_assets and len(goodwill_and_intangible_assets) > 0):
+
+    if goodwill_and_intangible_assets and len(goodwill_and_intangible_assets) > 0:
         score += 1
         details.append("Significant goodwill/intangible assets, suggesting brand value or IP")
-    
+
     # Scale score to 0-10 range
     final_score = min(10, score * 10 / 9)  # Max possible raw score is 9
-    
-    return {
-        "score": final_score,
-        "details": "; ".join(details)
-    }
+
+    return {"score": final_score, "details": "; ".join(details)}
 
 
 def analyze_management_quality(financial_line_items: list, insider_trades: list) -> dict:
@@ -274,28 +258,23 @@ def analyze_management_quality(financial_line_items: list, insider_trades: list)
     """
     score = 0
     details = []
-    
+
     if not financial_line_items:
-        return {
-            "score": 0,
-            "details": "Insufficient data to analyze management quality"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to analyze management quality"}
+
     # 1. Capital allocation - Check FCF to net income ratio
     # Munger values companies that convert earnings to cash
-    fcf_values = [item.free_cash_flow for item in financial_line_items 
-                 if hasattr(item, 'free_cash_flow') and item.free_cash_flow is not None]
-    
-    net_income_values = [item.net_income for item in financial_line_items 
-                        if hasattr(item, 'net_income') and item.net_income is not None]
-    
+    fcf_values = [item.free_cash_flow for item in financial_line_items if hasattr(item, "free_cash_flow") and item.free_cash_flow is not None]
+
+    net_income_values = [item.net_income for item in financial_line_items if hasattr(item, "net_income") and item.net_income is not None]
+
     if fcf_values and net_income_values and len(fcf_values) == len(net_income_values):
         # Calculate FCF to Net Income ratio for each period
         fcf_to_ni_ratios = []
         for i in range(len(fcf_values)):
             if net_income_values[i] and net_income_values[i] > 0:
                 fcf_to_ni_ratios.append(fcf_values[i] / net_income_values[i])
-        
+
         if fcf_to_ni_ratios:
             avg_ratio = sum(fcf_to_ni_ratios) / len(fcf_to_ni_ratios)
             if avg_ratio > 1.1:  # FCF > net income suggests good accounting
@@ -313,18 +292,16 @@ def analyze_management_quality(financial_line_items: list, insider_trades: list)
             details.append("Could not calculate FCF to Net Income ratios")
     else:
         details.append("Missing FCF or Net Income data")
-    
+
     # 2. Debt management - Munger is cautious about debt
-    debt_values = [item.total_debt for item in financial_line_items 
-                  if hasattr(item, 'total_debt') and item.total_debt is not None]
-    
-    equity_values = [item.shareholders_equity for item in financial_line_items 
-                    if hasattr(item, 'shareholders_equity') and item.shareholders_equity is not None]
-    
+    debt_values = [item.total_debt for item in financial_line_items if hasattr(item, "total_debt") and item.total_debt is not None]
+
+    equity_values = [item.shareholders_equity for item in financial_line_items if hasattr(item, "shareholders_equity") and item.shareholders_equity is not None]
+
     if debt_values and equity_values and len(debt_values) == len(equity_values):
         # Calculate D/E ratio for most recent period
-        recent_de_ratio = debt_values[0] / equity_values[0] if equity_values[0] > 0 else float('inf')
-        
+        recent_de_ratio = debt_values[0] / equity_values[0] if equity_values[0] > 0 else float("inf")
+
         if recent_de_ratio < 0.3:  # Very low debt
             score += 3
             details.append(f"Conservative debt management: D/E ratio of {recent_de_ratio:.2f}")
@@ -338,17 +315,15 @@ def analyze_management_quality(financial_line_items: list, insider_trades: list)
             details.append(f"High debt level: D/E ratio of {recent_de_ratio:.2f}")
     else:
         details.append("Missing debt or equity data")
-    
+
     # 3. Cash management efficiency - Munger values appropriate cash levels
-    cash_values = [item.cash_and_equivalents for item in financial_line_items
-                  if hasattr(item, 'cash_and_equivalents') and item.cash_and_equivalents is not None]
-    revenue_values = [item.revenue for item in financial_line_items
-                     if hasattr(item, 'revenue') and item.revenue is not None]
-    
+    cash_values = [item.cash_and_equivalents for item in financial_line_items if hasattr(item, "cash_and_equivalents") and item.cash_and_equivalents is not None]
+    revenue_values = [item.revenue for item in financial_line_items if hasattr(item, "revenue") and item.revenue is not None]
+
     if cash_values and revenue_values and len(cash_values) > 0 and len(revenue_values) > 0:
         # Calculate cash to revenue ratio (Munger likes 10-20% for most businesses)
         cash_to_revenue = cash_values[0] / revenue_values[0] if revenue_values[0] > 0 else 0
-        
+
         if 0.1 <= cash_to_revenue <= 0.25:
             # Goldilocks zone - not too much, not too little
             score += 2
@@ -365,15 +340,13 @@ def analyze_management_quality(financial_line_items: list, insider_trades: list)
             details.append(f"Low cash reserves: Cash/Revenue ratio of {cash_to_revenue:.2f}")
     else:
         details.append("Insufficient cash or revenue data")
-    
+
     # 4. Insider activity - Munger values skin in the game
     if insider_trades and len(insider_trades) > 0:
         # Count buys vs. sells
-        buys = sum(1 for trade in insider_trades if hasattr(trade, 'transaction_type') and 
-                   trade.transaction_type and trade.transaction_type.lower() in ['buy', 'purchase'])
-        sells = sum(1 for trade in insider_trades if hasattr(trade, 'transaction_type') and 
-                    trade.transaction_type and trade.transaction_type.lower() in ['sell', 'sale'])
-        
+        buys = sum(1 for trade in insider_trades if hasattr(trade, "transaction_type") and trade.transaction_type and trade.transaction_type.lower() in ["buy", "purchase"])
+        sells = sum(1 for trade in insider_trades if hasattr(trade, "transaction_type") and trade.transaction_type and trade.transaction_type.lower() in ["sell", "sale"])
+
         # Calculate the buy ratio
         total_trades = buys + sells
         if total_trades > 0:
@@ -393,11 +366,10 @@ def analyze_management_quality(financial_line_items: list, insider_trades: list)
             details.append("No recorded insider transactions")
     else:
         details.append("No insider trading data available")
-    
+
     # 5. Consistency in share count - Munger prefers stable/decreasing shares
-    share_counts = [item.outstanding_shares for item in financial_line_items
-                   if hasattr(item, 'outstanding_shares') and item.outstanding_shares is not None]
-    
+    share_counts = [item.outstanding_shares for item in financial_line_items if hasattr(item, "outstanding_shares") and item.outstanding_shares is not None]
+
     if share_counts and len(share_counts) >= 3:
         if share_counts[0] < share_counts[-1] * 0.95:  # 5%+ reduction in shares
             score += 2
@@ -412,15 +384,12 @@ def analyze_management_quality(financial_line_items: list, insider_trades: list)
             details.append("Moderate share count increase over time")
     else:
         details.append("Insufficient share count data")
-    
+
     # Scale score to 0-10 range
     # Maximum possible raw score would be 12 (3+3+2+2+2)
     final_score = max(0, min(10, score * 10 / 12))
-    
-    return {
-        "score": final_score,
-        "details": "; ".join(details)
-    }
+
+    return {"score": final_score, "details": "; ".join(details)}
 
 
 def analyze_predictability(financial_line_items: list) -> dict:
@@ -430,24 +399,20 @@ def analyze_predictability(financial_line_items: list) -> dict:
     """
     score = 0
     details = []
-    
+
     if not financial_line_items or len(financial_line_items) < 5:
-        return {
-            "score": 0,
-            "details": "Insufficient data to analyze business predictability (need 5+ years)"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to analyze business predictability (need 5+ years)"}
+
     # 1. Revenue stability and growth
-    revenues = [item.revenue for item in financial_line_items 
-               if hasattr(item, 'revenue') and item.revenue is not None]
-    
+    revenues = [item.revenue for item in financial_line_items if hasattr(item, "revenue") and item.revenue is not None]
+
     if revenues and len(revenues) >= 5:
         # Calculate year-over-year growth rates
-        growth_rates = [(revenues[i] / revenues[i+1] - 1) for i in range(len(revenues)-1)]
-        
+        growth_rates = [(revenues[i] / revenues[i + 1] - 1) for i in range(len(revenues) - 1)]
+
         avg_growth = sum(growth_rates) / len(growth_rates)
         growth_volatility = sum(abs(r - avg_growth) for r in growth_rates) / len(growth_rates)
-        
+
         if avg_growth > 0.05 and growth_volatility < 0.1:
             # Steady, consistent growth (Munger loves this)
             score += 3
@@ -464,15 +429,14 @@ def analyze_predictability(financial_line_items: list) -> dict:
             details.append(f"Declining or highly unpredictable revenue: {avg_growth:.1%} avg growth")
     else:
         details.append("Insufficient revenue history for predictability analysis")
-    
+
     # 2. Operating income stability
-    op_income = [item.operating_income for item in financial_line_items 
-                if hasattr(item, 'operating_income') and item.operating_income is not None]
-    
+    op_income = [item.operating_income for item in financial_line_items if hasattr(item, "operating_income") and item.operating_income is not None]
+
     if op_income and len(op_income) >= 5:
         # Count positive operating income periods
         positive_periods = sum(1 for income in op_income if income > 0)
-        
+
         if positive_periods == len(op_income):
             # Consistently profitable operations
             score += 3
@@ -489,16 +453,15 @@ def analyze_predictability(financial_line_items: list) -> dict:
             details.append(f"Unpredictable operations: Operating income positive in only {positive_periods}/{len(op_income)} periods")
     else:
         details.append("Insufficient operating income history")
-    
+
     # 3. Margin consistency - Munger values stable margins
-    op_margins = [item.operating_margin for item in financial_line_items 
-                 if hasattr(item, 'operating_margin') and item.operating_margin is not None]
-    
+    op_margins = [item.operating_margin for item in financial_line_items if hasattr(item, "operating_margin") and item.operating_margin is not None]
+
     if op_margins and len(op_margins) >= 5:
         # Calculate margin volatility
         avg_margin = sum(op_margins) / len(op_margins)
         margin_volatility = sum(abs(m - avg_margin) for m in op_margins) / len(op_margins)
-        
+
         if margin_volatility < 0.03:  # Very stable margins
             score += 2
             details.append(f"Highly predictable margins: {avg_margin:.1%} avg with minimal volatility")
@@ -509,15 +472,14 @@ def analyze_predictability(financial_line_items: list) -> dict:
             details.append(f"Unpredictable margins: {avg_margin:.1%} avg with high volatility ({margin_volatility:.1%})")
     else:
         details.append("Insufficient margin history")
-    
+
     # 4. Cash generation reliability
-    fcf_values = [item.free_cash_flow for item in financial_line_items 
-                 if hasattr(item, 'free_cash_flow') and item.free_cash_flow is not None]
-    
+    fcf_values = [item.free_cash_flow for item in financial_line_items if hasattr(item, "free_cash_flow") and item.free_cash_flow is not None]
+
     if fcf_values and len(fcf_values) >= 5:
         # Count positive FCF periods
         positive_fcf_periods = sum(1 for fcf in fcf_values if fcf > 0)
-        
+
         if positive_fcf_periods == len(fcf_values):
             # Consistently positive FCF
             score += 2
@@ -530,15 +492,12 @@ def analyze_predictability(financial_line_items: list) -> dict:
             details.append(f"Unpredictable cash generation: Positive FCF in only {positive_fcf_periods}/{len(fcf_values)} periods")
     else:
         details.append("Insufficient free cash flow history")
-    
+
     # Scale score to 0-10 range
     # Maximum possible raw score would be 10 (3+3+2+2)
     final_score = min(10, score * 10 / 10)
-    
-    return {
-        "score": final_score,
-        "details": "; ".join(details)
-    }
+
+    return {"score": final_score, "details": "; ".join(details)}
 
 
 def calculate_munger_valuation(financial_line_items: list, market_cap: float) -> dict:
@@ -550,37 +509,26 @@ def calculate_munger_valuation(financial_line_items: list, market_cap: float) ->
     """
     score = 0
     details = []
-    
+
     if not financial_line_items or market_cap is None:
-        return {
-            "score": 0,
-            "details": "Insufficient data to perform valuation"
-        }
-    
+        return {"score": 0, "details": "Insufficient data to perform valuation"}
+
     # Get FCF values (Munger's preferred "owner earnings" metric)
-    fcf_values = [item.free_cash_flow for item in financial_line_items 
-                 if hasattr(item, 'free_cash_flow') and item.free_cash_flow is not None]
-    
+    fcf_values = [item.free_cash_flow for item in financial_line_items if hasattr(item, "free_cash_flow") and item.free_cash_flow is not None]
+
     if not fcf_values or len(fcf_values) < 3:
-        return {
-            "score": 0,
-            "details": "Insufficient free cash flow data for valuation"
-        }
-    
+        return {"score": 0, "details": "Insufficient free cash flow data for valuation"}
+
     # 1. Normalize earnings by taking average of last 3-5 years
     # (Munger prefers to normalize earnings to avoid over/under-valuation based on cyclical factors)
-    normalized_fcf = sum(fcf_values[:min(5, len(fcf_values))]) / min(5, len(fcf_values))
-    
+    normalized_fcf = sum(fcf_values[: min(5, len(fcf_values))]) / min(5, len(fcf_values))
+
     if normalized_fcf <= 0:
-        return {
-            "score": 0,
-            "details": f"Negative or zero normalized FCF ({normalized_fcf}), cannot value",
-            "intrinsic_value": None
-        }
-    
+        return {"score": 0, "details": f"Negative or zero normalized FCF ({normalized_fcf}), cannot value", "intrinsic_value": None}
+
     # 2. Calculate FCF yield (inverse of P/FCF multiple)
     fcf_yield = normalized_fcf / market_cap
-    
+
     # 3. Apply Munger's FCF multiple based on business quality
     # Munger would pay higher multiples for wonderful businesses
     # Let's use a sliding scale where higher FCF yields are more attractive
@@ -595,16 +543,16 @@ def calculate_munger_valuation(financial_line_items: list, market_cap: float) ->
         details.append(f"Fair value: {fcf_yield:.1%} FCF yield")
     else:
         details.append(f"Expensive: Only {fcf_yield:.1%} FCF yield")
-    
+
     # 4. Calculate simple intrinsic value range
     # Munger tends to use straightforward valuations, avoiding complex DCF models
     conservative_value = normalized_fcf * 10  # 10x FCF = 10% yield
-    reasonable_value = normalized_fcf * 15    # 15x FCF ≈ 6.7% yield
-    optimistic_value = normalized_fcf * 20    # 20x FCF = 5% yield
-    
+    reasonable_value = normalized_fcf * 15  # 15x FCF ≈ 6.7% yield
+    optimistic_value = normalized_fcf * 20  # 20x FCF = 5% yield
+
     # 5. Calculate margins of safety
     current_to_reasonable = (reasonable_value - market_cap) / market_cap
-    
+
     if current_to_reasonable > 0.3:  # >30% upside
         score += 3
         details.append(f"Large margin of safety: {current_to_reasonable:.1%} upside to reasonable value")
@@ -616,13 +564,13 @@ def calculate_munger_valuation(financial_line_items: list, market_cap: float) ->
         details.append(f"Fair price: Within 10% of reasonable value ({current_to_reasonable:.1%})")
     else:
         details.append(f"Expensive: {-current_to_reasonable:.1%} premium to reasonable value")
-    
+
     # 6. Check earnings trajectory for additional context
     # Munger likes growing owner earnings
     if len(fcf_values) >= 3:
         recent_avg = sum(fcf_values[:3]) / 3
         older_avg = sum(fcf_values[-3:]) / 3 if len(fcf_values) >= 6 else fcf_values[-1]
-        
+
         if recent_avg > older_avg * 1.2:  # >20% growth in FCF
             score += 3
             details.append("Growing FCF trend adds to intrinsic value")
@@ -631,22 +579,12 @@ def calculate_munger_valuation(financial_line_items: list, market_cap: float) ->
             details.append("Stable to growing FCF supports valuation")
         else:
             details.append("Declining FCF trend is concerning")
-    
+
     # Scale score to 0-10 range
     # Maximum possible raw score would be 10 (4+3+3)
-    final_score = min(10, score * 10 / 10) 
-    
-    return {
-        "score": final_score,
-        "details": "; ".join(details),
-        "intrinsic_value_range": {
-            "conservative": conservative_value,
-            "reasonable": reasonable_value,
-            "optimistic": optimistic_value
-        },
-        "fcf_yield": fcf_yield,
-        "normalized_fcf": normalized_fcf
-    }
+    final_score = min(10, score * 10 / 10)
+
+    return {"score": final_score, "details": "; ".join(details), "intrinsic_value_range": {"conservative": conservative_value, "reasonable": reasonable_value, "optimistic": optimistic_value}, "fcf_yield": fcf_yield, "normalized_fcf": normalized_fcf}
 
 
 def analyze_news_sentiment(news_items: list) -> str:
@@ -656,24 +594,25 @@ def analyze_news_sentiment(news_items: list) -> str:
     """
     if not news_items or len(news_items) == 0:
         return "No news data available"
-    
+
     # Just return a simple count for now - in a real implementation, this would use NLP
     return f"Qualitative review of {len(news_items)} recent news items would be needed"
 
 
 def generate_munger_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> CharlieMungerSignal:
     """
     Generates investment decisions in the style of Charlie Munger.
     """
-    template = ChatPromptTemplate.from_messages([
-        (
-            "system",
-            """You are a Charlie Munger AI agent, making investment decisions using his principles:
+    template = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """You are a Charlie Munger AI agent, making investment decisions using his principles:
 
             1. Focus on the quality and predictability of the business.
             2. Rely on mental models from multiple disciplines to analyze investments.
@@ -705,11 +644,11 @@ def generate_munger_output(
             
             For example, if bullish: "The high ROIC of 22% demonstrates the company's moat. When applying basic microeconomics, we can see that competitors would struggle to..."
             For example, if bearish: "I see this business making a classic mistake in capital allocation. As I've often said about [relevant Mungerism], this company appears to be..."
-            """
-        ),
-        (
-            "human",
-            """Based on the following analysis, create a Munger-style investment signal.
+            """,
+            ),
+            (
+                "human",
+                """Based on the following analysis, create a Munger-style investment signal.
 
             Analysis Data for {ticker}:
             {analysis_data}
@@ -720,27 +659,21 @@ def generate_munger_output(
               "confidence": float (0-100),
               "reasoning": "string"
             }}
-            """
-        )
-    ])
+            """,
+            ),
+        ]
+    )
 
-    prompt = template.invoke({
-        "analysis_data": json.dumps(analysis_data, indent=2),
-        "ticker": ticker
-    })
+    prompt = template.invoke({"analysis_data": json.dumps(analysis_data, indent=2), "ticker": ticker})
 
     def create_default_charlie_munger_signal():
-        return CharlieMungerSignal(
-            signal="neutral",
-            confidence=0.0,
-            reasoning="Error in analysis, defaulting to neutral"
-        )
+        return CharlieMungerSignal(signal="neutral", confidence=0.0, reasoning="Error in analysis, defaulting to neutral")
 
     return call_llm(
-        prompt=prompt, 
-        model_name=model_name, 
-        model_provider=model_provider, 
-        pydantic_model=CharlieMungerSignal, 
-        agent_name="charlie_munger_agent", 
+        prompt=prompt,
+        model_name=model_name,
+        model_provider=model_provider,
+        pydantic_model=CharlieMungerSignal,
+        agent_name="charlie_munger_agent",
         default_factory=create_default_charlie_munger_signal,
     )

--- a/src/agents/peter_lynch.py
+++ b/src/agents/peter_lynch.py
@@ -1,25 +1,29 @@
+import json
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel
+from typing_extensions import Literal
+
 from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import (
-    get_financial_metrics,
-    get_market_cap,
-    search_line_items,
-    get_insider_trades,
     get_company_news,
+    get_financial_metrics,
+    get_insider_trades,
+    get_market_cap,
     get_prices,
+    search_line_items,
 )
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel
-import json
-from typing_extensions import Literal
-from src.utils.progress import progress
 from src.utils.llm import call_llm
+from src.utils.progress import progress
 
 
 class PeterLynchSignal(BaseModel):
     """
     Container for the Peter Lynch-style output signal.
     """
+
     signal: Literal["bullish", "bearish", "neutral"]
     confidence: float
     reasoning: str
@@ -106,13 +110,7 @@ def peter_lynch_agent(state: AgentState):
         # Combine partial scores with weights typical for Peter Lynch:
         #   30% Growth, 25% Valuation, 20% Fundamentals,
         #   15% Sentiment, 10% Insider Activity = 100%
-        total_score = (
-            growth_analysis["score"] * 0.30
-            + valuation_analysis["score"] * 0.25
-            + fundamentals_analysis["score"] * 0.20
-            + sentiment_analysis["score"] * 0.15
-            + insider_activity["score"] * 0.10
-        )
+        total_score = growth_analysis["score"] * 0.30 + valuation_analysis["score"] * 0.25 + fundamentals_analysis["score"] * 0.20 + sentiment_analysis["score"] * 0.15 + insider_activity["score"] * 0.10
 
         max_possible_score = 10.0
 
@@ -440,7 +438,7 @@ def analyze_insider_activity(insider_trades: list) -> dict:
 
 def generate_lynch_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> PeterLynchSignal:
@@ -492,11 +490,7 @@ def generate_lynch_output(
     prompt = template.invoke({"analysis_data": json.dumps(analysis_data, indent=2), "ticker": ticker})
 
     def create_default_signal():
-        return PeterLynchSignal(
-            signal="neutral",
-            confidence=0.0,
-            reasoning="Error in analysis; defaulting to neutral"
-        )
+        return PeterLynchSignal(signal="neutral", confidence=0.0, reasoning="Error in analysis; defaulting to neutral")
 
     return call_llm(
         prompt=prompt,

--- a/src/agents/warren_buffett.py
+++ b/src/agents/warren_buffett.py
@@ -1,9 +1,12 @@
-from src.graph.state import AgentState, show_agent_reasoning
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.messages import HumanMessage
-from pydantic import BaseModel
 import json
+from typing import Any
+
+from langchain_core.messages import HumanMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel
 from typing_extensions import Literal
+
+from src.graph.state import AgentState, show_agent_reasoning
 from src.tools.api import get_financial_metrics, get_market_cap, search_line_items
 from src.utils.llm import call_llm
 from src.utils.progress import progress
@@ -136,7 +139,7 @@ def warren_buffett_agent(state: AgentState):
     return {"messages": [message], "data": state["data"]}
 
 
-def analyze_fundamentals(metrics: list) -> dict[str, any]:
+def analyze_fundamentals(metrics: list) -> dict[str, Any]:
     """Analyze company fundamentals based on Buffett's criteria."""
     if not metrics:
         return {"score": 0, "details": "Insufficient fundamental data"}
@@ -185,7 +188,7 @@ def analyze_fundamentals(metrics: list) -> dict[str, any]:
     return {"score": score, "details": "; ".join(reasoning), "metrics": latest_metrics.model_dump()}
 
 
-def analyze_consistency(financial_line_items: list) -> dict[str, any]:
+def analyze_consistency(financial_line_items: list) -> dict[str, Any]:
     """Analyze earnings consistency and growth."""
     if len(financial_line_items) < 4:  # Need at least 4 periods for trend analysis
         return {"score": 0, "details": "Insufficient historical data"}
@@ -218,7 +221,7 @@ def analyze_consistency(financial_line_items: list) -> dict[str, any]:
     }
 
 
-def analyze_moat(metrics: list) -> dict[str, any]:
+def analyze_moat(metrics: list) -> dict[str, Any]:
     """
     Evaluate whether the company likely has a durable competitive advantage (moat).
     For simplicity, we look at stability of ROE/operating margins over multiple periods
@@ -268,7 +271,7 @@ def analyze_moat(metrics: list) -> dict[str, any]:
     }
 
 
-def analyze_management_quality(financial_line_items: list) -> dict[str, any]:
+def analyze_management_quality(financial_line_items: list) -> dict[str, Any]:
     """
     Checks for share dilution or consistent buybacks, and some dividend track record.
     A simplified approach:
@@ -308,7 +311,7 @@ def analyze_management_quality(financial_line_items: list) -> dict[str, any]:
     }
 
 
-def calculate_owner_earnings(financial_line_items: list) -> dict[str, any]:
+def calculate_owner_earnings(financial_line_items: list) -> dict[str, Any]:
     """Calculate owner earnings (Buffett's preferred measure of true earnings power).
     Owner Earnings = Net Income + Depreciation - Maintenance CapEx"""
     if not financial_line_items or len(financial_line_items) < 1:
@@ -334,7 +337,7 @@ def calculate_owner_earnings(financial_line_items: list) -> dict[str, any]:
     }
 
 
-def calculate_intrinsic_value(financial_line_items: list) -> dict[str, any]:
+def calculate_intrinsic_value(financial_line_items: list) -> dict[str, Any]:
     """Calculate intrinsic value using DCF with owner earnings."""
     if not financial_line_items:
         return {"intrinsic_value": None, "details": ["Insufficient data for valuation"]}
@@ -386,7 +389,7 @@ def calculate_intrinsic_value(financial_line_items: list) -> dict[str, any]:
 
 def generate_buffett_output(
     ticker: str,
-    analysis_data: dict[str, any],
+    analysis_data: dict[str, Any],
     model_name: str,
     model_provider: str,
 ) -> WarrenBuffettSignal:

--- a/src/data/cache.py
+++ b/src/data/cache.py
@@ -1,12 +1,15 @@
+from typing import Any
+
+
 class Cache:
     """In-memory cache for API responses."""
 
     def __init__(self):
-        self._prices_cache: dict[str, list[dict[str, any]]] = {}
-        self._financial_metrics_cache: dict[str, list[dict[str, any]]] = {}
-        self._line_items_cache: dict[str, list[dict[str, any]]] = {}
-        self._insider_trades_cache: dict[str, list[dict[str, any]]] = {}
-        self._company_news_cache: dict[str, list[dict[str, any]]] = {}
+        self._prices_cache: dict[str, list[dict[str, Any]]] = {}
+        self._financial_metrics_cache: dict[str, list[dict[str, Any]]] = {}
+        self._line_items_cache: dict[str, list[dict[str, Any]]] = {}
+        self._insider_trades_cache: dict[str, list[dict[str, Any]]] = {}
+        self._company_news_cache: dict[str, list[dict[str, Any]]] = {}
 
     def _merge_data(self, existing: list[dict] | None, new_data: list[dict], key_field: str) -> list[dict]:
         """Merge existing and new data, avoiding duplicates based on a key field."""
@@ -21,43 +24,43 @@ class Cache:
         merged.extend([item for item in new_data if item[key_field] not in existing_keys])
         return merged
 
-    def get_prices(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_prices(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached price data if available."""
         return self._prices_cache.get(ticker)
 
-    def set_prices(self, ticker: str, data: list[dict[str, any]]):
+    def set_prices(self, ticker: str, data: list[dict[str, Any]]):
         """Append new price data to cache."""
         self._prices_cache[ticker] = self._merge_data(self._prices_cache.get(ticker), data, key_field="time")
 
-    def get_financial_metrics(self, ticker: str) -> list[dict[str, any]]:
+    def get_financial_metrics(self, ticker: str) -> list[dict[str, Any]]:
         """Get cached financial metrics if available."""
         return self._financial_metrics_cache.get(ticker)
 
-    def set_financial_metrics(self, ticker: str, data: list[dict[str, any]]):
+    def set_financial_metrics(self, ticker: str, data: list[dict[str, Any]]):
         """Append new financial metrics to cache."""
         self._financial_metrics_cache[ticker] = self._merge_data(self._financial_metrics_cache.get(ticker), data, key_field="report_period")
 
-    def get_line_items(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_line_items(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached line items if available."""
         return self._line_items_cache.get(ticker)
 
-    def set_line_items(self, ticker: str, data: list[dict[str, any]]):
+    def set_line_items(self, ticker: str, data: list[dict[str, Any]]):
         """Append new line items to cache."""
         self._line_items_cache[ticker] = self._merge_data(self._line_items_cache.get(ticker), data, key_field="report_period")
 
-    def get_insider_trades(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_insider_trades(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached insider trades if available."""
         return self._insider_trades_cache.get(ticker)
 
-    def set_insider_trades(self, ticker: str, data: list[dict[str, any]]):
+    def set_insider_trades(self, ticker: str, data: list[dict[str, Any]]):
         """Append new insider trades to cache."""
         self._insider_trades_cache[ticker] = self._merge_data(self._insider_trades_cache.get(ticker), data, key_field="filing_date")  # Could also use transaction_date if preferred
 
-    def get_company_news(self, ticker: str) -> list[dict[str, any]] | None:
+    def get_company_news(self, ticker: str) -> list[dict[str, Any]] | None:
         """Get cached company news if available."""
         return self._company_news_cache.get(ticker)
 
-    def set_company_news(self, ticker: str, data: list[dict[str, any]]):
+    def set_company_news(self, ticker: str, data: list[dict[str, Any]]):
         """Append new company news to cache."""
         self._company_news_cache[ticker] = self._merge_data(self._company_news_cache.get(ticker), data, key_field="date")
 

--- a/src/graph/state.py
+++ b/src/graph/state.py
@@ -1,21 +1,20 @@
+import json
+import operator
+from typing import Any
+
+from langchain_core.messages import BaseMessage
 from typing_extensions import Annotated, Sequence, TypedDict
 
-import operator
-from langchain_core.messages import BaseMessage
 
-
-import json
-
-
-def merge_dicts(a: dict[str, any], b: dict[str, any]) -> dict[str, any]:
+def merge_dicts(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
     return {**a, **b}
 
 
 # Define agent state
 class AgentState(TypedDict):
     messages: Annotated[Sequence[BaseMessage], operator.add]
-    data: Annotated[dict[str, any], merge_dicts]
-    metadata: Annotated[dict[str, any], merge_dicts]
+    data: Annotated[dict[str, Any], merge_dicts]
+    metadata: Annotated[dict[str, Any], merge_dicts]
 
 
 def show_agent_reasoning(output, agent_name):


### PR DESCRIPTION
## Summary
- fix inconsistent `dict[str, any]` type annotations
- add required `typing.Any` imports
- format with isort and black

## Testing
- `isort src/data/cache.py src/graph/state.py src/agents/peter_lynch.py src/agents/cathie_wood.py src/agents/charlie_munger.py src/agents/ben_graham.py src/agents/phil_fisher.py src/agents/stanley_druckenmiller.py src/agents/bill_ackman.py src/agents/warren_buffett.py src/agents/aswath_damodaran.py`
- `black src/data/cache.py src/graph/state.py src/agents/peter_lynch.py src/agents/cathie_wood.py src/agents/charlie_munger.py src/agents/ben_graham.py src/agents/phil_fisher.py src/agents/stanley_druckenmiller.py src/agents/bill_ackman.py src/agents/warren_buffett.py src/agents/aswath_damodaran.py`
- `pytest -q` *(fails: `pytest` command not found)*